### PR TITLE
docs: remove betterem extension

### DIFF
--- a/mkdocs.yaml
+++ b/mkdocs.yaml
@@ -54,8 +54,6 @@ markdown_extensions:
       permalink: true
   - pymdownx.arithmatex:
       generic: true
-  - pymdownx.betterem:
-      smart_enable: all
   - pymdownx.caret
   - pymdownx.critic
   - pymdownx.details


### PR DESCRIPTION
Remove the betterem extension to fix the broken bold styling on the website.

fixes #33

related to https://github.com/CCBR/CHAMPAGNE/issues/53