### PR TITLE
Fixed link for Dockers repo

### DIFF
--- a/docs/other.md
+++ b/docs/other.md
@@ -9,7 +9,7 @@ hide:
     - gfa programs for Non-B site at NCI/FNLCR. gfa is a Suite of programs developed at NCI-Frederick/Frederick National Lab to find sequences associated with non-B DNA forming motifs.
 * [spacesavers2](https://github.com/abcsFrederick/spacesavers2)
     - Spacesavers2 has a suite of tools to quickly crawl through a file system to identify duplicates, assess per-user or per-project disk usage and monitor disk allocation with a monthly report
-* [Dockers](https://github.com/abcsFrederick/Dockers)
+* [Dockers](https://github.com/abcsFrederick/Dockers2)
     - A large collection of 100+ CCBRs Docker recipes.
 * [pyrkit](https://github.com/abcsFrederick/pyrkit)
     - A tool to archive and co-locate NGS data with project-level, sample-level, and analysis-specific metadata prior to depositing in HPCDME.


### PR DESCRIPTION
Fixed broken link for the Dockers repo as part of Link Checker Report #55 